### PR TITLE
Add condition question sets for symptom checker

### DIFF
--- a/public/data/conditions.json
+++ b/public/data/conditions.json
@@ -1,0 +1,237 @@
+{
+  "headache": {
+    "title": "Headache safety check",
+    "questions": [
+      {
+        "type": "radio",
+        "name": "onset",
+        "label": "Did the headache start very suddenly (within a minute)?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "neuro",
+        "label": "Any weakness, confusion, or vision problems?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "injury",
+        "label": "Head injury in the past 7 days?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "duration",
+        "label": "How long has this headache been going on?",
+        "options": ["< 24 hours", "1-3 days", "4-7 days", "> 7 days"]
+      }
+    ],
+    "alerts": [
+      {
+        "field": "onset",
+        "equals": "Yes",
+        "message": "Sudden severe headache can be serious. Seek urgent medical assessment."
+      },
+      {
+        "any": [
+          {"field": "neuro", "equals": "Yes"},
+          {"field": "injury", "equals": "Yes"}
+        ],
+        "message": "Neurological changes or recent head injury need same-day medical advice."
+      },
+      {
+        "field": "duration",
+        "equals": "> 7 days",
+        "message": "Headaches lasting more than a week should be checked by a GP."
+      }
+    ]
+  },
+  "hayfever": {
+    "title": "Hay fever safety check",
+    "questions": [
+      {
+        "type": "radio",
+        "name": "breathing",
+        "label": "Any wheeze, chest tightness, or breathing difficulty?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "eyeSymptoms",
+        "label": "Are your eyes very red, painful, or affected by discharge?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "pregnancy",
+        "label": "Is the person pregnant or breastfeeding?",
+        "options": ["Pregnant", "Breastfeeding", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "ageGroup",
+        "label": "Who is this for?",
+        "options": ["Adult", "Teen 13-17", "Child 6-12", "Child under 6"]
+      }
+    ],
+    "alerts": [
+      {
+        "field": "breathing",
+        "equals": "Yes",
+        "message": "Breathing difficulty with allergies needs urgent medical review."
+      },
+      {
+        "any": [
+          {"field": "pregnancy", "equals": "Pregnant"},
+          {"field": "pregnancy", "equals": "Breastfeeding"}
+        ],
+        "message": "Pregnancy and breastfeeding require pharmacist advice before treatment."
+      },
+      {
+        "field": "ageGroup",
+        "equals": "Child under 6",
+        "message": "Young children with hay fever should be assessed by a pharmacist or GP."
+      }
+    ]
+  },
+  "indigestion": {
+    "title": "Heartburn & indigestion check",
+    "questions": [
+      {
+        "type": "radio",
+        "name": "alarm",
+        "label": "Difficulty swallowing, vomiting blood, or unexplained weight loss?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "chestPain",
+        "label": "Is the pain spreading to your arm, jaw, back, or with shortness of breath?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "duration",
+        "label": "How long have the symptoms been present?",
+        "options": ["< 1 week", "1-3 weeks", "> 3 weeks"]
+      },
+      {
+        "type": "text",
+        "name": "tried",
+        "label": "Treatments already tried"
+      }
+    ],
+    "alerts": [
+      {
+        "any": [
+          {"field": "alarm", "equals": "Yes"},
+          {"field": "chestPain", "equals": "Yes"}
+        ],
+        "message": "Urgent assessment is needed for alarm symptoms or chest pain with indigestion."
+      },
+      {
+        "field": "duration",
+        "equals": "> 3 weeks",
+        "message": "Persistent indigestion longer than 3 weeks should be reviewed by a GP."
+      }
+    ]
+  },
+  "diarrhoea": {
+    "title": "Diarrhoea safety check",
+    "questions": [
+      {
+        "type": "radio",
+        "name": "blood",
+        "label": "Any blood or black, tarry stools?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "fever",
+        "label": "High fever (above 38.5°C)?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "duration",
+        "label": "How long have the loose stools lasted?",
+        "options": ["< 48 hours", "3-5 days", "> 5 days"]
+      },
+      {
+        "type": "radio",
+        "name": "travel",
+        "label": "Recent travel abroad?",
+        "options": ["Yes", "No"]
+      }
+    ],
+    "alerts": [
+      {
+        "field": "blood",
+        "equals": "Yes",
+        "message": "Blood in stool needs urgent medical advice."
+      },
+      {
+        "field": "fever",
+        "equals": "Yes",
+        "message": "High fever with diarrhoea requires assessment by a clinician."
+      },
+      {
+        "field": "duration",
+        "equals": "> 5 days",
+        "message": "Diarrhoea lasting more than 5 days should be reviewed by a GP."
+      },
+      {
+        "field": "travel",
+        "equals": "Yes",
+        "message": "Recent travel with diarrhoea can indicate infection – seek advice."
+      }
+    ]
+  },
+  "sorethroat": {
+    "title": "Sore throat safety check",
+    "questions": [
+      {
+        "type": "radio",
+        "name": "breathing",
+        "label": "Any difficulty breathing, drooling, or struggling to swallow saliva?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "rash",
+        "label": "Is there a widespread rash or are you feeling very unwell?",
+        "options": ["Yes", "No"]
+      },
+      {
+        "type": "radio",
+        "name": "duration",
+        "label": "How long has the sore throat lasted?",
+        "options": ["< 3 days", "4-7 days", "> 7 days"]
+      },
+      {
+        "type": "radio",
+        "name": "contact",
+        "label": "Close contact with someone diagnosed with scarlet fever, strep throat, or COVID-19?",
+        "options": ["Yes", "No"]
+      }
+    ],
+    "alerts": [
+      {
+        "field": "breathing",
+        "equals": "Yes",
+        "message": "Breathing or swallowing difficulty needs urgent medical help."
+      },
+      {
+        "field": "rash",
+        "equals": "Yes",
+        "message": "Severe rash or feeling very unwell should be checked by a clinician."
+      },
+      {
+        "field": "duration",
+        "equals": "> 7 days",
+        "message": "Sore throats lasting longer than a week require GP review."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the missing `public/data/conditions.json` dataset consumed by the stepper-based symptom checker
- provide question metadata and red-flag alerts for headache, hay fever, indigestion, diarrhoea, and sore throat flows

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c973e4aa7083279b30874fb4bc9d7e