### PR TITLE
Fix checklist navigation validation, add favicon, and polish UI

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -6,6 +6,7 @@
   <title>About — Pharmalogic</title>
   <meta name="description" content="About the Pharmalogic OTC Medication Advisor project." />
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>

--- a/public/check.html
+++ b/public/check.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/chat.css" />
   <link rel="stylesheet" href="css/check.css" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>

--- a/public/contact.html
+++ b/public/contact.html
@@ -6,6 +6,7 @@
   <title>Contact — Pharmalogic</title>
   <meta name="description" content="Contact the Pharmalogic team." />
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>

--- a/public/css/check.css
+++ b/public/css/check.css
@@ -32,6 +32,15 @@
   .card.soft { background: rgba(255,255,255,.03); }
   .actions { display: flex; gap: 10px; margin-top: 14px; }
   
-  fieldset { border: 1px solid rgba(255,255,255,.12); border-radius: var(--radius-sm); padding: 12px; }
-  legend { padding: 0 6px; }
-  
+  fieldset {
+    border: 1px solid rgba(255,255,255,.16);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    background: rgba(12,17,25,.65);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  }
+  legend {
+    padding: 0 6px;
+    font-weight: 600;
+    color: #fff;
+  }

--- a/public/css/results.css
+++ b/public/css/results.css
@@ -58,6 +58,15 @@ body.bg-gray-50 {
 .inline-block { display: inline-block; }
 .flex { display: flex; }
 .gap-4 { gap: 1rem; }
+.items-start { align-items: flex-start; }
+.border-l-4 { border-left-width: 4px; border-left-style: solid; border-left-color: currentColor; }
+.pl-4 { padding-left: 1rem; }
+.w-5 { width: 1.25rem; }
+.h-5 { height: 1.25rem; }
+.mr-2 { margin-right: 0.5rem; }
+.mt-0\.5 { margin-top: 0.125rem; }
+.list-none { list-style: none; }
+.pl-0 { padding-left: 0; }
 
 .bg-white { background-color: #fff; }
 .bg-gray-50 { background-color: var(--gray-50); }
@@ -65,6 +74,7 @@ body.bg-gray-50 {
 .bg-green-50 { background-color: var(--green-50); }
 .bg-yellow-50 { background-color: var(--yellow-50); }
 .bg-orange-50 { background-color: var(--orange-50); }
+.bg-red-50 { background-color: #fef2f2; }
 .bg-red-100 { background-color: var(--red-100); }
 .bg-teal-50 { background-color: var(--teal-50); }
 
@@ -74,6 +84,8 @@ body.bg-gray-50 {
 .text-gray-900 { color: var(--gray-900); }
 .text-blue-700 { color: var(--blue-700); }
 .text-blue-800 { color: var(--blue-800); }
+.text-red-500 { color: #ef4444; }
+.text-red-600 { color: #dc2626; }
 .text-red-700 { color: var(--red-700); }
 .text-red-800 { color: var(--red-800); }
 .text-green-700 { color: var(--green-700); }
@@ -83,6 +95,10 @@ body.bg-gray-50 {
 .text-yellow-800 { color: var(--yellow-800); }
 .text-teal-700 { color: var(--teal-700); }
 .text-teal-800 { color: var(--teal-800); }
+.text-purple-500 { color: #8b5cf6; }
+.text-purple-800 { color: #5b21b6; }
+.text-purple-900 { color: #4c1d95; }
+.text-purple-700 { color: #6d28d9; }
 
 .font-medium { font-weight: 500; }
 .font-semibold { font-weight: 600; }
@@ -101,9 +117,21 @@ body.bg-gray-50 {
 .border { border: 1px solid var(--gray-200); }
 .border-gray-200 { border-color: var(--gray-200); }
 .border-red-200 { border-color: var(--red-200); }
+.border-purple-200 { border-color: #ddd6fe; }
 .border-b-2 { border-bottom-width: 2px; }
 
 .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08); }
+
+.warning-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.warning-icon {
+  font-size: 1.15rem;
+  line-height: 1;
+}
 
 .h-8 { height: 2rem; }
 .w-8 { width: 2rem; }
@@ -160,4 +188,8 @@ button:disabled {
   .shadow-sm { box-shadow: none; }
   .results-layout { box-shadow: none; padding: 0; }
   .bg-blue-50, .bg-green-50, .bg-yellow-50, .bg-orange-50, .bg-red-100, .bg-teal-50 { background: transparent; }
+  .warning-icon { font-size: 1rem; }
+  .results-layout h1 { font-size: 1.75rem; }
+  .results-layout h2 { font-size: 1.3rem; }
+  .results-layout h3 { font-size: 1.1rem; }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -37,7 +37,7 @@
   
   /* Utilities */
   .container{max-width:var(--maxw); margin:0 auto; padding:0 20px}
-  .section{padding:64px 0}
+  .section{padding:64px 0;scroll-margin-top:96px}
   .section.compact{padding:40px 0}
   h1,h2,h3{line-height:1.25; margin:0 0 10px}
   p{margin:0 0 12px}
@@ -63,10 +63,36 @@
   .hero-copy h1{font-size:clamp(28px,4.6vw,52px)}
   .hero-copy p{color:var(--muted);max-width:640px}
   .hero-cta{display:flex;gap:12px;margin-top:14px}
-  .btn{display:inline-block;padding:12px 16px;border-radius:12px;text-decoration:none;font-weight:600}
-  .btn-primary{background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#091018;box-shadow:var(--shadow)}
-  .btn-ghost{border:1px solid rgba(255,255,255,.18);color:var(--ink)}
-  .btn-ghost:hover{background:rgba(255,255,255,.06)}
+  .btn{
+    display:inline-block;
+    padding:12px 16px;
+    border-radius:12px;
+    text-decoration:none;
+    font-weight:600;
+    border:1px solid transparent;
+    cursor:pointer;
+    transition:background-color .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+  }
+  .btn-primary{
+    background:linear-gradient(135deg,var(--brand),var(--brand-2));
+    color:#091018;
+    box-shadow:var(--shadow);
+    border-color:rgba(255,255,255,.16);
+  }
+  .btn-primary:hover{box-shadow:0 16px 40px rgba(46,197,182,.28)}
+  .btn-primary:focus-visible{outline:3px solid rgba(79,140,255,.65);outline-offset:3px}
+  .btn-ghost{
+    background:rgba(255,255,255,.08);
+    border-color:rgba(255,255,255,.32);
+    color:var(--ink);
+    box-shadow:0 12px 28px rgba(0,0,0,.28);
+  }
+  .btn-ghost:hover{
+    background:rgba(255,255,255,.12);
+    border-color:rgba(255,255,255,.45);
+    color:#fff;
+  }
+  .btn-ghost:focus-visible{outline:3px solid rgba(79,140,255,.65);outline-offset:3px}
   .trust-points{display:flex;gap:16px;list-style:none;margin:14px 0 0;padding:0;color:var(--muted);flex-wrap:wrap}
   
   .hero-art{
@@ -178,18 +204,43 @@ select,
 textarea {
   width: 100%;
   color: var(--ink);
-  background: rgba(255,255,255,.04);
-  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(12,17,25,.82);
+  border: 1px solid rgba(120,160,255,.22);
   border-radius: var(--radius-sm);
-  padding: 12px 12px;
+  padding: 12px 14px;
   outline: none;
-  transition: border-color .15s ease, box-shadow .15s ease;
+  transition: border-color .15s ease, box-shadow .15s ease, background-color .15s ease;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.04);
 }
 textarea { resize: vertical; }
 
-input:focus, select:focus, textarea:focus {
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='%23e9eef5' d='M4.47 6.47a.75.75 0 0 1 1.06 0L8 8.94l2.47-2.47a.75.75 0 0 1 1.06 1.06L8.53 10.53a.75.75 0 0 1-1.06 0L4.47 7.53a.75.75 0 0 1 0-1.06Z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: calc(100% - 14px) 50%;
+  background-size: 14px 14px;
+  padding-right: 44px;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: rgba(233,238,245,.65);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
   border-color: rgba(79,140,255,.6);
   box-shadow: 0 0 0 3px rgba(79,140,255,.18);
+  background: rgba(14,22,33,.92);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
 }
 
 .choice-row { display: flex; gap: 14px; flex-wrap: wrap; }

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Pharmalogic icon">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2ec5b6" />
+      <stop offset="100%" stop-color="#4f8cff" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="url(#grad)" />
+  <path d="M30 14h4a2 2 0 0 1 2 2v12h12a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H36v12a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2V36H16a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h12V16a2 2 0 0 1 2-2z" fill="#0e1116" />
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <title>Pharmalogic — OTC Medication Advisor</title>
   <meta name="description" content="WWHAM intake, interaction checks, and clear OTC guidance aligned to UK standards." />
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,14 @@
+// Ensure accidental editable states are disabled (some browsers retain them after devtools tweaks)
+if (document?.body?.isContentEditable) {
+  document.body.contentEditable = 'false';
+}
+if (document?.body?.hasAttribute('contenteditable')) {
+  document.body.removeAttribute('contenteditable');
+}
+if (document?.designMode === 'on') {
+  document.designMode = 'off';
+}
+
 // Mobile menu toggle with proper ARIA
 const toggle = document.querySelector('.nav-toggle');
 const menu = document.getElementById('menu');

--- a/public/js/pages/check.js
+++ b/public/js/pages/check.js
@@ -12,6 +12,27 @@ function go(to) {
 }
 let current = 1;
 
+function validateCurrentStep() {
+  const stepEl = steps.find(s => s.dataset.step === String(current));
+  if (!stepEl) return true;
+
+  const fields = stepEl.querySelectorAll('input, select, textarea');
+  for (const field of fields) {
+    if (field.disabled) continue;
+    if (!field.checkValidity()) {
+      if (typeof field.reportValidity === 'function') {
+        field.reportValidity();
+      } else {
+        form?.reportValidity?.();
+      }
+      field.focus?.();
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // Clear any persisted results when starting a fresh check
 window.StateManager?.clearState?.();
 
@@ -19,7 +40,7 @@ form?.addEventListener('click', (e) => {
   const nextBtn = e.target.closest('.next');
   const prevBtn = e.target.closest('.prev');
   if (nextBtn) {
-    if (!form.reportValidity()) return;
+    if (!validateCurrentStep()) return;
     if (current === 2) injectConditionQuestions(); // build step 3
     if (current === 3) buildReview();              // build step 4
     go(Math.min(current + 1, 4));

--- a/public/js/pages/results.js
+++ b/public/js/pages/results.js
@@ -312,7 +312,10 @@
         if (results.flags?.length) {
           warningContent.push(`
             <div class="bg-red-100 p-4 rounded-lg mb-4">
-              <h3 class="font-semibold text-red-800 mb-2">⚠️ Red Flags - Seek Medical Attention</h3>
+              <h3 class="font-semibold text-red-800 mb-2 warning-title">
+                <span class="warning-icon" aria-hidden="true">⚠️</span>
+                <span>Red flags – seek medical attention</span>
+              </h3>
               <ul class="list-disc ml-4 space-y-2">
                 ${results.flags.map(flag => `<li class="text-red-700">${flag}</li>`).join('')}
               </ul>
@@ -323,7 +326,10 @@
         if (results.warnings?.length) {
           warningContent.push(`
             <div class="bg-orange-50 p-4 rounded-lg">
-              <h3 class="font-semibold text-orange-800 mb-2">Important Safety Warnings</h3>
+              <h3 class="font-semibold text-orange-800 mb-2 warning-title">
+                <span class="warning-icon" aria-hidden="true">⚠️</span>
+                <span>Important safety warnings</span>
+              </h3>
               <ul class="list-disc ml-4 space-y-2">
                 ${results.warnings.map(warning => `<li class="text-orange-700">${warning}</li>`).join('')}
               </ul>

--- a/public/results.html
+++ b/public/results.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Medication Results — Pharmalogic</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="stylesheet" href="css/chat.css" />
     <link rel="stylesheet" href="css/check.css" />
     <link rel="stylesheet" href="css/results.css" />


### PR DESCRIPTION
## Summary
- limit guided checklist validation to the active step so the "Next" buttons advance correctly
- add a branded favicon and reference it from all pages so the site shows an icon in the browser tab
- refresh checklist inputs, dropdowns, and ghost buttons with higher-contrast styling and offset in-page anchors so sections aren’t hidden behind the sticky header
- remove the accidental editable caret state, tighten warning markup, and flesh out results utility classes so the print view renders icons and typography at consistent sizes

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cad4ed6a4483279811f5c3cae64c99