### PR TITLE
Escalate chat immediately on red-flag detection

### DIFF
--- a/public/js/modules/state-manager.js
+++ b/public/js/modules/state-manager.js
@@ -11,6 +11,8 @@ class StateManager {
         sessionStorage.setItem('answers', JSON.stringify(state.answers || {}));
         sessionStorage.setItem('flags', JSON.stringify(state.flags || []));
         sessionStorage.setItem('cautions', JSON.stringify(state.cautions || []));
+        sessionStorage.setItem('warnings', JSON.stringify(state.warnings || []));
+        sessionStorage.setItem('escalated', state.escalated ? 'true' : 'false');
     }
 
     static getStoredState() {
@@ -23,7 +25,9 @@ class StateManager {
             action: sessionStorage.getItem('action'),
             answers: JSON.parse(sessionStorage.getItem('answers') || '{}'),
             flags: JSON.parse(sessionStorage.getItem('flags') || '[]'),
-            cautions: JSON.parse(sessionStorage.getItem('cautions') || '[]')
+            cautions: JSON.parse(sessionStorage.getItem('cautions') || '[]'),
+            warnings: JSON.parse(sessionStorage.getItem('warnings') || '[]'),
+            escalated: sessionStorage.getItem('escalated') === 'true'
         };
     }
 
@@ -37,6 +41,8 @@ class StateManager {
         sessionStorage.removeItem('answers');
         sessionStorage.removeItem('flags');
         sessionStorage.removeItem('cautions');
+        sessionStorage.removeItem('warnings');
+        sessionStorage.removeItem('escalated');
     }
 
     static validateState() {

--- a/public/js/modules/state-manager.js
+++ b/public/js/modules/state-manager.js
@@ -4,9 +4,9 @@ class StateManager {
         // Save each piece of state individually
         sessionStorage.setItem('condition', state.condition);
         sessionStorage.setItem('who', state.who);
-        sessionStorage.setItem('what', state.what);
-        sessionStorage.setItem('duration', state.duration);
-        sessionStorage.setItem('meds', state.meds);
+        sessionStorage.setItem('what', state.what ?? '');
+        sessionStorage.setItem('duration', state.duration ?? '');
+        sessionStorage.setItem('meds', state.meds ?? '');
         sessionStorage.setItem('action', state.action ?? '');
         sessionStorage.setItem('answers', JSON.stringify(state.answers || {}));
         sessionStorage.setItem('flags', JSON.stringify(state.flags || []));

--- a/public/js/pages/results.js
+++ b/public/js/pages/results.js
@@ -213,6 +213,7 @@
     if (!state) return '<p class="text-gray-600">No patient details available.</p>';
     const items = [
       { label: 'Condition', value: state.condition || '-' },
+      { label: 'What', value: state.what || '-' },
       { label: 'Who', value: state.who || '-' },
       { label: 'Duration', value: state.duration || '-' },
       { label: 'Current meds', value: state.meds || '-' },

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -91,6 +91,11 @@ describe('chat analyseMessage edge cases', () => {
     expect(analysis.redFlags).toContain('Possible emergency symptoms mentioned.');
   });
 
+  it('ignores negated red flag statements that explicitly deny symptoms', () => {
+    const analysis = chatInternals.analyzeMessage('He is not vomiting blood or collapsing, just a mild upset stomach.');
+    expect(analysis.redFlags).toEqual([]);
+  });
+
   it('normalises structured red flags returned by heuristic NLU helper', () => {
     analyzeMock.mockReturnValue({ redFlags: ['vomit(ing)? blood'] });
     const analysis = chatInternals.analyzeMessage('');
@@ -105,6 +110,20 @@ describe('chat analyseMessage edge cases', () => {
   it('captures negative medication statements for the meds slot', () => {
     const value = chatInternals.fillSlotFromText('No other medications at all.', 'meds');
     expect(value).toBe('none');
+  });
+
+  it('maps explicit 12-year-old phrasing to the child demographic', () => {
+    const value = chatInternals.fillSlotFromText('It is for my 12-year-old son.', 'who');
+    expect(value).toBe('child 5–12');
+  });
+
+  it('detects conflicting who information for ambiguous statements', () => {
+    const mentions = chatInternals.detectWhoMentions('This is for my 12-year-old who is pregnant.');
+    expect(mentions).toEqual(expect.arrayContaining(['child 5–12', 'pregnant']));
+  });
+
+  it('treats negated keywords as non-affirmative in helper', () => {
+    expect(chatInternals.textHasAffirmativePattern('not vomiting blood or collapsing', /vomiting blood/i)).toBe(false);
   });
 });
 
@@ -127,5 +146,19 @@ describe('chat safety evaluation escalation paths', () => {
   it('ignores calm filler text without adding unnecessary flags', () => {
     chatInternals.evaluateSafety('Just checking in, nothing major to report besides feeling fine.');
     expect(chatInternals.state.flags).toEqual([]);
+  });
+
+  it('does not trigger flags when concerning symptoms are explicitly denied', () => {
+    chatInternals.state.condition = 'diarrhoea';
+    chatInternals.evaluateSafety('No blood, no fever, just mild cramping.');
+    expect(chatInternals.state.flags).toEqual([]);
+  });
+
+  it('escalates immediately and stops further questions when a flag is detected', () => {
+    chatInternals.state.condition = 'headache';
+    chatInternals.evaluateSafety('Worst ever headache with collapse.');
+    expect(chatInternals.state.escalated).toBe(true);
+    expect(chatInternals.state.step).toBe('escalated');
+    expect(chatInternals.getNextQuestion()).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add state tracking so any detected red flag immediately triggers an escalation response and stops further questioning
- guard chat flow and safety handling to avoid additional prompts once escalation is active and reuse the urgent warning message on follow-up inputs
- extend chat tests to confirm red-flag detection flips the conversation into escalation mode and suppresses follow-up questions

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caf57ae77483278137831519643409